### PR TITLE
move integration test setup into testutils

### DIFF
--- a/internal/controller/nats/controller_integration_test.go
+++ b/internal/controller/nats/controller_integration_test.go
@@ -7,13 +7,14 @@ import (
 
 	"github.com/kyma-project/nats-manager/api/v1alpha1"
 	"github.com/kyma-project/nats-manager/testutils"
+	"github.com/kyma-project/nats-manager/testutils/integration"
 	natsmatchers "github.com/kyma-project/nats-manager/testutils/matchers/nats"
 	"github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
 	"github.com/stretchr/testify/require"
 )
 
-var testEnvironment *IntegrationTestEnvironment //nolint:gochecknoglobals // used in tests
+var testEnvironment *integration.TestEnvironment //nolint:gochecknoglobals // used in tests
 
 // TestMain pre-hook and post-hook to run before and after all tests.
 func TestMain(m *testing.M) {
@@ -22,7 +23,7 @@ func TestMain(m *testing.M) {
 
 	// setup env test
 	var err error
-	testEnvironment, err = NewIntegrationTestEnvironment()
+	testEnvironment, err = integration.NewTestEnvironment()
 	if err != nil {
 		panic(err)
 	}
@@ -67,7 +68,7 @@ func Test_CreateNATSCR(t *testing.T) {
 
 			// given
 			// create unique namespace for this test run.
-			givenNamespace := NewTestNamespace()
+			givenNamespace := integration.NewTestNamespace()
 			require.NoError(t, testEnvironment.CreateNamespace(ctx, givenNamespace))
 
 			// update namespace in resources.

--- a/internal/controller/nats/integration_test.go
+++ b/internal/controller/nats/integration_test.go
@@ -181,7 +181,7 @@ func (ite IntegrationTestEnvironment) CreateNamespace(ctx context.Context, names
 	}
 	// create namespace
 	ns := testutils.NewNamespace(namespace)
-	err := testEnvironment.k8sClient.Create(ctx, ns)
+	err := ite.k8sClient.Create(ctx, ns)
 	if !k8serrors.IsAlreadyExists(err) {
 		return err
 	}

--- a/testutils/integration/integration.go
+++ b/testutils/integration/integration.go
@@ -44,7 +44,7 @@ const (
 	SmallPollingInterval     = 1 * time.Second
 )
 
-// MockedUnitTestEnvironment provides mocked resources for unit tests.
+// TestEnvironment provides mocked resources for integration tests.
 type TestEnvironment struct {
 	Context         context.Context
 	EnvTestInstance *envtest.Environment

--- a/testutils/integration/integration.go
+++ b/testutils/integration/integration.go
@@ -1,4 +1,4 @@
-package nats_test
+package integration
 
 import (
 	"context"
@@ -45,7 +45,7 @@ const (
 )
 
 // MockedUnitTestEnvironment provides mocked resources for unit tests.
-type IntegrationTestEnvironment struct {
+type TestEnvironment struct {
 	Context         context.Context
 	EnvTestInstance *envtest.Environment
 	k8sClient       client.Client
@@ -58,7 +58,7 @@ type IntegrationTestEnvironment struct {
 	TestCancelFn    context.CancelFunc
 }
 
-func NewIntegrationTestEnvironment() (*IntegrationTestEnvironment, error) {
+func NewTestEnvironment() (*TestEnvironment, error) {
 	var err error
 	// setup context
 	ctx := context.Background()
@@ -143,7 +143,7 @@ func NewIntegrationTestEnvironment() (*IntegrationTestEnvironment, error) {
 		}
 	}()
 
-	return &IntegrationTestEnvironment{
+	return &TestEnvironment{
 		Context:         ctx,
 		k8sClient:       k8sClient,
 		KubeClient:      &kubeClient,
@@ -157,7 +157,7 @@ func NewIntegrationTestEnvironment() (*IntegrationTestEnvironment, error) {
 	}, nil
 }
 
-func (ite IntegrationTestEnvironment) TearDown() error {
+func (ite TestEnvironment) TearDown() error {
 	if ite.TestCancelFn != nil {
 		ite.TestCancelFn()
 	}
@@ -175,7 +175,7 @@ func (ite IntegrationTestEnvironment) TearDown() error {
 	return err
 }
 
-func (ite IntegrationTestEnvironment) CreateNamespace(ctx context.Context, namespace string) error {
+func (ite TestEnvironment) CreateNamespace(ctx context.Context, namespace string) error {
 	if namespace == "default" {
 		return nil
 	}
@@ -188,11 +188,11 @@ func (ite IntegrationTestEnvironment) CreateNamespace(ctx context.Context, names
 	return nil
 }
 
-func (ite IntegrationTestEnvironment) EnsureK8sResourceCreated(t *testing.T, obj client.Object) {
+func (ite TestEnvironment) EnsureK8sResourceCreated(t *testing.T, obj client.Object) {
 	require.NoError(t, ite.k8sClient.Create(ite.Context, obj))
 }
 
-func (ite IntegrationTestEnvironment) GetNATSFromK8s(name, namespace string) (natsv1alpha1.NATS, error) {
+func (ite TestEnvironment) GetNATSFromK8s(name, namespace string) (natsv1alpha1.NATS, error) {
 	var nats natsv1alpha1.NATS
 	err := ite.k8sClient.Get(ite.Context, k8stypes.NamespacedName{
 		Name:      name,
@@ -201,7 +201,7 @@ func (ite IntegrationTestEnvironment) GetNATSFromK8s(name, namespace string) (na
 	return nats, err
 }
 
-func (ite IntegrationTestEnvironment) GetStatefulSetFromK8s(name, namespace string) (*appsv1.StatefulSet, error) {
+func (ite TestEnvironment) GetStatefulSetFromK8s(name, namespace string) (*appsv1.StatefulSet, error) {
 	nn := k8stypes.NamespacedName{
 		Name:      name,
 		Namespace: namespace,
@@ -213,12 +213,12 @@ func (ite IntegrationTestEnvironment) GetStatefulSetFromK8s(name, namespace stri
 	return result, nil
 }
 
-func (ite IntegrationTestEnvironment) UpdateStatefulSetStatusOnK8s(sts appsv1.StatefulSet) error {
+func (ite TestEnvironment) UpdateStatefulSetStatusOnK8s(sts appsv1.StatefulSet) error {
 	return ite.k8sClient.Status().Update(ite.Context, &sts)
 }
 
 // GetNATSAssert fetches a NATS from k8s and allows making assertions on it.
-func (ite IntegrationTestEnvironment) GetNATSAssert(g *gomega.GomegaWithT,
+func (ite TestEnvironment) GetNATSAssert(g *gomega.GomegaWithT,
 	nats *natsv1alpha1.NATS) gomega.AsyncAssertion {
 	return g.Eventually(func() *natsv1alpha1.NATS {
 		gotNATS, err := ite.GetNATSFromK8s(nats.Name, nats.Namespace)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:
move the integration test into the testutil	package because

- reduces clutter  `/integration/controller/nats`
- reduces confusion over a `_test.go` file that does not contain any tests
- make the integration test reusable in other packages.

- **Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
