### PR TITLE
add validation of `memStorage` and `fileStorage`

### DIFF
--- a/api/v1alpha1/nats_types.go
+++ b/api/v1alpha1/nats_types.go
@@ -128,6 +128,7 @@ type Cluster struct {
 type JetStream struct {
 	// MemStorage defines configurations to memory storage in NATS JetStream.
 	// +kubebuilder:default:={size:"20Mi",enabled:false}
+	// +kubebuilder:validation:XValidation:rule="!self.enabled || self.size != 0", message="can only be enabled if size is not 0"
 	MemStorage `json:"memStorage,omitempty"`
 
 	// FileStorage defines configurations to file storage in NATS JetStream.

--- a/api/v1alpha1/nats_types.go
+++ b/api/v1alpha1/nats_types.go
@@ -98,6 +98,7 @@ type NATSSpec struct {
 
 	// JetStream defines configurations that are specific to NATS JetStream.
 	// +kubebuilder:default:={fileStorage:{storageClassName:"default", size:"1Gi"},memStorage:{size:"20Mi",enabled:false}}
+	// +kubebuilder:validation:XValidation:rule="self.fileStorage == oldSelf.fileStorage",message="fileStorage is immutable once it was set"
 	JetStream `json:"jetStream,omitempty"`
 
 	// JetStream defines configurations that are specific to NATS logging in NATS.
@@ -133,6 +134,7 @@ type JetStream struct {
 
 	// FileStorage defines configurations to file storage in NATS JetStream.
 	// +kubebuilder:default:={storageClassName:"default",size:"1Gi"}
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="fileStorage is immutable once it was set"
 	FileStorage `json:"fileStorage,omitempty"`
 }
 
@@ -151,10 +153,12 @@ type MemStorage struct {
 type FileStorage struct {
 	// StorageClassName defines the file storage class name.
 	// +kubebuilder:default:="default"
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="fileStorage is immutable once it was set"
 	StorageClassName string `json:"storageClassName,omitempty"`
 
 	// Size defines the file storage size.
 	// +kubebuilder:default:="1Gi"
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="fileStorage is immutable once it was set"
 	Size resource.Quantity `json:"size,omitempty"`
 }
 

--- a/config/crd/bases/operator.kyma-project.io_nats.yaml
+++ b/config/crd/bases/operator.kyma-project.io_nats.yaml
@@ -110,12 +110,21 @@ spec:
                         description: Size defines the file storage size.
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
+                        x-kubernetes-validations:
+                        - message: fileStorage is immutable once it was set
+                          rule: self == oldSelf
                       storageClassName:
                         default: default
                         description: StorageClassName defines the file storage class
                           name.
                         type: string
+                        x-kubernetes-validations:
+                        - message: fileStorage is immutable once it was set
+                          rule: self == oldSelf
                     type: object
+                    x-kubernetes-validations:
+                    - message: fileStorage is immutable once it was set
+                      rule: self == oldSelf
                   memStorage:
                     default:
                       enabled: false
@@ -140,6 +149,9 @@ spec:
                     - message: can only be enabled if size is not 0
                       rule: '!self.enabled || self.size != 0'
                 type: object
+                x-kubernetes-validations:
+                - message: fileStorage is immutable once it was set
+                  rule: self.fileStorage == oldSelf.fileStorage
               labels:
                 additionalProperties:
                   type: string

--- a/config/crd/bases/operator.kyma-project.io_nats.yaml
+++ b/config/crd/bases/operator.kyma-project.io_nats.yaml
@@ -136,6 +136,9 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                     type: object
+                    x-kubernetes-validations:
+                    - message: can only be enabled if size is not 0
+                      rule: '!self.enabled || self.size != 0'
                 type: object
               labels:
                 additionalProperties:

--- a/internal/controller/nats/integrationtests/validation/integration_test.go
+++ b/internal/controller/nats/integrationtests/validation/integration_test.go
@@ -107,7 +107,7 @@ func Test_Validate_CreateNatsCR(t *testing.T) {
 			err := testEnvironment.CreateK8sResource(tc.givenNATS)
 
 			// then
-			if tc.wantErrMsg == "" {
+			if tc.wantErrMsg == noError {
 				require.NoError(t, err)
 			} else {
 				require.Contains(t, err.Error(), tc.wantErrMsg)
@@ -138,27 +138,11 @@ func Test_NATSCR_Defaulting(t *testing.T) {
 				},
 			},
 			wantMatches: gomega.And(
-				natsmatchers.HaveSpecClusterSize(3),
-				natsmatchers.HaveSpecResources(corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						"cpu":    resource.MustParse("20m"),
-						"memory": resource.MustParse("64Mi"),
-					},
-					Requests: corev1.ResourceList{
-						"cpu":    resource.MustParse("5m"),
-						"memory": resource.MustParse("16Mi"),
-					},
-				}),
-				natsmatchers.HaveSpecLoggingTrace(false),
-				natsmatchers.HaveSpecLoggingDebug(false),
-				natsmatchers.HaveSpecJetsStreamMemStorage(v1alpha1.MemStorage{
-					Enabled: false,
-					Size:    resource.MustParse("20Mi"),
-				}),
-				natsmatchers.HaveSpecJetStreamFileStorage(v1alpha1.FileStorage{
-					StorageClassName: "default",
-					Size:             resource.MustParse("1Gi"),
-				}),
+				natsmatchers.HaveSpecCluster(defaultCluster()),
+				natsmatchers.HaveSpecResources(defaultResources()),
+				natsmatchers.HaveSpecLogging(defaultLogging()),
+				natsmatchers.HaveSpecJetsStreamMemStorage(defaultMemStorage()),
+				natsmatchers.HaveSpecJetStreamFileStorage(defaultFileStorage()),
 			),
 		},
 		{
@@ -175,27 +159,11 @@ func Test_NATSCR_Defaulting(t *testing.T) {
 				},
 			},
 			wantMatches: gomega.And(
-				natsmatchers.HaveSpecClusterSize(3),
-				natsmatchers.HaveSpecResources(corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						"cpu":    resource.MustParse("20m"),
-						"memory": resource.MustParse("64Mi"),
-					},
-					Requests: corev1.ResourceList{
-						"cpu":    resource.MustParse("5m"),
-						"memory": resource.MustParse("16Mi"),
-					},
-				}),
-				natsmatchers.HaveSpecLoggingTrace(false),
-				natsmatchers.HaveSpecLoggingDebug(false),
-				natsmatchers.HaveSpecJetsStreamMemStorage(v1alpha1.MemStorage{
-					Enabled: false,
-					Size:    resource.MustParse("20Mi"),
-				}),
-				natsmatchers.HaveSpecJetStreamFileStorage(v1alpha1.FileStorage{
-					StorageClassName: "default",
-					Size:             resource.MustParse("1Gi"),
-				}),
+				natsmatchers.HaveSpecCluster(defaultCluster()),
+				natsmatchers.HaveSpecResources(defaultResources()),
+				natsmatchers.HaveSpecLogging(defaultLogging()),
+				natsmatchers.HaveSpecJetsStreamMemStorage(defaultMemStorage()),
+				natsmatchers.HaveSpecJetStreamFileStorage(defaultFileStorage()),
 			),
 		},
 		{
@@ -214,7 +182,7 @@ func Test_NATSCR_Defaulting(t *testing.T) {
 				},
 			},
 			wantMatches: gomega.And(
-				natsmatchers.HaveSpecClusterSize(3),
+				natsmatchers.HaveSpecCluster(defaultCluster()),
 			),
 		},
 		{
@@ -233,14 +201,8 @@ func Test_NATSCR_Defaulting(t *testing.T) {
 				},
 			},
 			wantMatches: gomega.And(
-				natsmatchers.HaveSpecJetsStreamMemStorage(v1alpha1.MemStorage{
-					Enabled: false,
-					Size:    resource.MustParse("20Mi"),
-				}),
-				natsmatchers.HaveSpecJetStreamFileStorage(v1alpha1.FileStorage{
-					StorageClassName: "default",
-					Size:             resource.MustParse("1Gi"),
-				}),
+				natsmatchers.HaveSpecJetsStreamMemStorage(defaultMemStorage()),
+				natsmatchers.HaveSpecJetStreamFileStorage(defaultFileStorage()),
 			),
 		},
 		{
@@ -262,14 +224,8 @@ func Test_NATSCR_Defaulting(t *testing.T) {
 				},
 			},
 			wantMatches: gomega.And(
-				natsmatchers.HaveSpecJetsStreamMemStorage(v1alpha1.MemStorage{
-					Enabled: false,
-					Size:    resource.MustParse("20Mi"),
-				}),
-				natsmatchers.HaveSpecJetStreamFileStorage(v1alpha1.FileStorage{
-					StorageClassName: "default",
-					Size:             resource.MustParse("1Gi"),
-				}),
+				natsmatchers.HaveSpecJetsStreamMemStorage(defaultMemStorage()),
+				natsmatchers.HaveSpecJetStreamFileStorage(defaultFileStorage()),
 			),
 		},
 		{
@@ -288,8 +244,7 @@ func Test_NATSCR_Defaulting(t *testing.T) {
 				},
 			},
 			wantMatches: gomega.And(
-				natsmatchers.HaveSpecLoggingTrace(false),
-				natsmatchers.HaveSpecLoggingDebug(false),
+				natsmatchers.HaveSpecLogging(defaultLogging()),
 			),
 		},
 	}
@@ -315,4 +270,42 @@ func Test_NATSCR_Defaulting(t *testing.T) {
 			}).Should(tc.wantMatches)
 		})
 	}
+}
+
+func defaultResources() corev1.ResourceRequirements {
+	return corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			"cpu":    resource.MustParse("20m"),
+			"memory": resource.MustParse("64Mi"),
+		},
+		Requests: corev1.ResourceList{
+			"cpu":    resource.MustParse("5m"),
+			"memory": resource.MustParse("16Mi"),
+		},
+	}
+}
+
+func defaultMemStorage() v1alpha1.MemStorage {
+	return v1alpha1.MemStorage{
+		Enabled: false,
+		Size:    resource.MustParse("20Mi"),
+	}
+}
+
+func defaultFileStorage() v1alpha1.FileStorage {
+	return v1alpha1.FileStorage{
+		StorageClassName: "default",
+		Size:             resource.MustParse("1Gi"),
+	}
+}
+
+func defaultLogging() v1alpha1.Logging {
+	return v1alpha1.Logging{
+		Debug: false,
+		Trace: false,
+	}
+}
+
+func defaultCluster() v1alpha1.Cluster {
+	return v1alpha1.Cluster{Size: 3}
 }

--- a/internal/controller/nats/integrationtests/validation/integration_test.go
+++ b/internal/controller/nats/integrationtests/validation/integration_test.go
@@ -37,6 +37,7 @@ const (
 	namespace      = "namespace"
 	kindNATS       = "NATS"
 	size           = "size"
+	enabled        = "enabled"
 	apiVersionNATS = "operator.kyma-project.io/v1alpha1"
 )
 
@@ -131,6 +132,72 @@ func Test_Validate_CreateNATS(t *testing.T) {
 			},
 			wantErrMsg: "should be greater than or equal to 1",
 		},
+		{
+			name: `validation of spec.jetStream.memStorage passes if enabled is true and size is not 0`,
+			givenUnstructuredNATS: unstructured.Unstructured{
+				Object: map[string]any{
+					kind:       kindNATS,
+					apiVersion: apiVersionNATS,
+					metadata: map[string]any{
+						name:      testutils.GetRandK8sName(7),
+						namespace: testutils.GetRandK8sName(7),
+					},
+					spec: map[string]any{
+						jetStream: map[string]any{
+							memStorage: map[string]any{
+								enabled: true,
+								size:    "1Gi",
+							},
+						},
+					},
+				},
+			},
+			wantErrMsg: noError,
+		},
+		{
+			name: `validation of spec.jetStream.memStorage passes if size is 0 but enabled is false`,
+			givenUnstructuredNATS: unstructured.Unstructured{
+				Object: map[string]any{
+					kind:       kindNATS,
+					apiVersion: apiVersionNATS,
+					metadata: map[string]any{
+						name:      testutils.GetRandK8sName(7),
+						namespace: testutils.GetRandK8sName(7),
+					},
+					spec: map[string]any{
+						jetStream: map[string]any{
+							memStorage: map[string]any{
+								enabled: false,
+								size:    0,
+							},
+						},
+					},
+				},
+			},
+			wantErrMsg: noError,
+		},
+		{
+			name: `validation of spec.jetStream.memStorage fails if enabled is true but size is 0`,
+			givenUnstructuredNATS: unstructured.Unstructured{
+				Object: map[string]any{
+					kind:       kindNATS,
+					apiVersion: apiVersionNATS,
+					metadata: map[string]any{
+						name:      testutils.GetRandK8sName(7),
+						namespace: testutils.GetRandK8sName(7),
+					},
+					spec: map[string]any{
+						jetStream: map[string]any{
+							memStorage: map[string]any{
+								enabled: true,
+								size:    0,
+							},
+						},
+					},
+				},
+			},
+			wantErrMsg: "can only be enabled if size is not 0",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -142,7 +209,7 @@ func Test_Validate_CreateNATS(t *testing.T) {
 			testEnvironment.EnsureNamespaceCreation(t, tc.givenUnstructuredNATS.GetNamespace())
 
 			// when
-			err := testEnvironment.CreateUnstructK8sResourceWithError(&tc.givenUnstructuredNATS)
+			err := testEnvironment.CreateUnstructuredK8sResource(&tc.givenUnstructuredNATS)
 
 			// then
 			if tc.wantErrMsg == noError {

--- a/testutils/integration/integration.go
+++ b/testutils/integration/integration.go
@@ -229,6 +229,21 @@ func (env TestEnvironment) EnsureK8sResourceUpdated(t *testing.T, obj client.Obj
 	require.NoError(t, env.k8sClient.Update(env.Context, obj))
 }
 
+func (env TestEnvironment) UpdatedNATSInK8s(nats *natsv1alpha1.NATS, options ...testutils.NATSOption) error {
+	natsOnK8s, err := env.GetNATSFromK8s(nats.Name, nats.Namespace)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, o := range options {
+		if er := o(&natsOnK8s); er != nil {
+			panic(er)
+		}
+	}
+
+	return env.k8sClient.Update(env.Context, &natsOnK8s)
+}
+
 func (env TestEnvironment) EnsureK8sResourceDeleted(t *testing.T, obj client.Object) {
 	require.NoError(t, env.k8sClient.Delete(env.Context, obj))
 }

--- a/testutils/integration/integration.go
+++ b/testutils/integration/integration.go
@@ -221,7 +221,7 @@ func (env TestEnvironment) EnsureK8sUnStructResourceCreated(t *testing.T, obj *u
 	require.NoError(t, env.k8sClient.Create(env.Context, obj))
 }
 
-func (env TestEnvironment) CreateUnstructK8sResourceWithError(obj *unstructured.Unstructured) error {
+func (env TestEnvironment) CreateUnstructuredK8sResource(obj *unstructured.Unstructured) error {
 	return env.k8sClient.Create(env.Context, obj)
 }
 

--- a/testutils/integration/integration.go
+++ b/testutils/integration/integration.go
@@ -229,15 +229,19 @@ func (env TestEnvironment) EnsureK8sResourceUpdated(t *testing.T, obj client.Obj
 	require.NoError(t, env.k8sClient.Update(env.Context, obj))
 }
 
-func (env TestEnvironment) UpdatedNATSInK8s(nats *natsv1alpha1.NATS, opts ...testutils.NATSOption) error {
+func (env TestEnvironment) UpdatedNATSInK8s(nats *natsv1alpha1.NATS, options ...testutils.NATSOption) error {
 	natsOnK8s, err := env.GetNATSFromK8s(nats.Name, nats.Namespace)
 	if err != nil {
 		panic(err)
 	}
 
-	patchedNATS := testutils.GetPatchedNATS(natsOnK8s, opts...)
+	for _, o := range options {
+		if er := o(&natsOnK8s); er != nil {
+			panic(er)
+		}
+	}
 
-	return env.k8sClient.Update(env.Context, &patchedNATS)
+	return env.k8sClient.Update(env.Context, &natsOnK8s)
 }
 
 func (env TestEnvironment) EnsureK8sResourceDeleted(t *testing.T, obj client.Object) {

--- a/testutils/integration/integration.go
+++ b/testutils/integration/integration.go
@@ -221,6 +221,10 @@ func (env TestEnvironment) EnsureK8sUnStructResourceCreated(t *testing.T, obj *u
 	require.NoError(t, env.k8sClient.Create(env.Context, obj))
 }
 
+func (env TestEnvironment) CreateUnstructK8sResourceWithError(obj *unstructured.Unstructured) error {
+	return env.k8sClient.Create(env.Context, obj)
+}
+
 func (env TestEnvironment) EnsureK8sResourceUpdated(t *testing.T, obj client.Object) {
 	require.NoError(t, env.k8sClient.Update(env.Context, obj))
 }

--- a/testutils/integration/integration.go
+++ b/testutils/integration/integration.go
@@ -229,19 +229,15 @@ func (env TestEnvironment) EnsureK8sResourceUpdated(t *testing.T, obj client.Obj
 	require.NoError(t, env.k8sClient.Update(env.Context, obj))
 }
 
-func (env TestEnvironment) UpdatedNATSInK8s(nats *natsv1alpha1.NATS, options ...testutils.NATSOption) error {
+func (env TestEnvironment) UpdatedNATSInK8s(nats *natsv1alpha1.NATS, opts ...testutils.NATSOption) error {
 	natsOnK8s, err := env.GetNATSFromK8s(nats.Name, nats.Namespace)
 	if err != nil {
 		panic(err)
 	}
 
-	for _, o := range options {
-		if er := o(&natsOnK8s); er != nil {
-			panic(er)
-		}
-	}
+	patchedNATS := testutils.GetPatchedNATS(natsOnK8s, opts...)
 
-	return env.k8sClient.Update(env.Context, &natsOnK8s)
+	return env.k8sClient.Update(env.Context, &patchedNATS)
 }
 
 func (env TestEnvironment) EnsureK8sResourceDeleted(t *testing.T, obj client.Object) {

--- a/testutils/matchers/nats/matchers.go
+++ b/testutils/matchers/nats/matchers.go
@@ -1,6 +1,8 @@
 package nats
 
 import (
+	"reflect"
+
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/gstruct"
 	gomegatypes "github.com/onsi/gomega/types"
@@ -36,11 +38,31 @@ func HaveSpecJetStreamFileStorage(fs v1alpha1.FileStorage) gomegatypes.GomegaMat
 	)
 }
 
+func HaveSpecCluster(cluster v1alpha1.Cluster) gomegatypes.GomegaMatcher {
+	return gomega.WithTransform(
+		func(n *v1alpha1.NATS) bool {
+			return reflect.DeepEqual(n.Spec.Cluster, cluster)
+		}, gomega.BeTrue())
+}
+
 func HaveSpecClusterSize(size int) gomegatypes.GomegaMatcher {
 	return gomega.WithTransform(
 		func(n *v1alpha1.NATS) int {
 			return n.Spec.Cluster.Size
 		}, gomega.Equal(size))
+}
+
+func HaveSpecLogging(logging v1alpha1.Logging) gomegatypes.GomegaMatcher {
+	return gomega.And(
+		gomega.WithTransform(
+			func(n *v1alpha1.NATS) bool {
+				return n.Spec.Logging.Debug
+			}, gomega.Equal(logging.Debug)),
+		gomega.WithTransform(
+			func(n *v1alpha1.NATS) bool {
+				return n.Spec.Logging.Trace
+			}, gomega.Equal(logging.Trace)),
+	)
 }
 
 func HaveSpecLoggingDebug(enabled bool) gomegatypes.GomegaMatcher {

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -154,16 +154,6 @@ func NewNATSCR(opts ...NATSOption) *v1alpha1.NATS {
 	return nats
 }
 
-// GetPatchedNATS takes nats and patches it via opts.
-func GetPatchedNATS(nats v1alpha1.NATS, opts ...NATSOption) v1alpha1.NATS {
-	for _, opt := range opts {
-		if err := opt(&nats); err != nil {
-			panic(err)
-		}
-	}
-	return nats
-}
-
 func NewDestinationRuleCRD() *apiextensionsv1.CustomResourceDefinition {
 	result := &apiextensionsv1.CustomResourceDefinition{
 		TypeMeta: metav1.TypeMeta{

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -136,7 +136,7 @@ func NewNATSCR(opts ...NATSOption) *v1alpha1.NATS {
 		// Name, UUID, Kind, APIVersion
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1alpha1",
-			Kind:       "Nats",
+			Kind:       "NATS",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -154,6 +154,16 @@ func NewNATSCR(opts ...NATSOption) *v1alpha1.NATS {
 	return nats
 }
 
+// GetPatchedNATS takes nats and patches it via opts.
+func GetPatchedNATS(nats v1alpha1.NATS, opts ...NATSOption) v1alpha1.NATS {
+	for _, opt := range opts {
+		if err := opt(&nats); err != nil {
+			panic(err)
+		}
+	}
+	return nats
+}
+
 func NewDestinationRuleCRD() *apiextensionsv1.CustomResourceDefinition {
 	result := &apiextensionsv1.CustomResourceDefinition{
 		TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

add validation of `spec.jetStream.memStorage`: memStorage can only be enabled if size is not 0.
add validation of `spec.jetStream.fileStorage`: fileStorage cannot be edited once it was set
also, refactored some of the existing tests.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
