### PR TITLE
Added validation for spec.memStorage.size does not surpass spec.resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ bin/*
 
 # Vendor
 vendor/
+.env.dev

--- a/api/v1alpha1/nats_types.go
+++ b/api/v1alpha1/nats_types.go
@@ -80,6 +80,7 @@ type NATS struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// +kubebuilder:default:={jetStream:{fileStorage:{storageClassName:"default", size:"1Gi"},memStorage:{size:"20Mi",enabled:false}}, cluster:{size:3},logging:{trace:false,debug:false}, resources:{limits:{cpu:"20m",memory:"64Mi"}, requests:{cpu:"5m",memory:"16Mi"}}}
+	// +kubebuilder:validation:XValidation:rule="!self.jetStream.memStorage.enabled || self.jetStream.memStorage.size < self.resources.limits.memory", message="memStorage.size should be less than resources.limits.memory."
 	Spec   NATSSpec   `json:"spec,omitempty"`
 	Status NATSStatus `json:"status,omitempty"`
 }

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -22,7 +22,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/config/crd/bases/operator.kyma-project.io_nats.yaml
+++ b/config/crd/bases/operator.kyma-project.io_nats.yaml
@@ -229,6 +229,10 @@ spec:
                     type: object
                 type: object
             type: object
+            x-kubernetes-validations:
+            - message: memStorage.size should be less than resources.limits.memory.
+              rule: '!self.jetStream.memStorage.enabled || self.jetStream.memStorage.size
+                < self.resources.limits.memory'
           status:
             description: NATSStatus defines the observed state of NATS.
             properties:


### PR DESCRIPTION

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Added validation for `spec.memStorage.size` does not surpass spec.resources

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/nats-manager/issues/68