### PR TITLE
Added e2e upgrade from fast-channel to current commit test jobs

### DIFF
--- a/.github/workflows/pull-with-lifecycle-manager.yaml
+++ b/.github/workflows/pull-with-lifecycle-manager.yaml
@@ -70,13 +70,103 @@ jobs:
           make -C hack/ci/ download-module-template
           kubectl apply -f module-template.yaml --dry-run=client
 
-      - name: Install & enabled NATS module template
+      - name: Install & enable NATS module template
         run: |
           make -C hack/ci/ install-module-template
           make -C hack/ci/ enable-module-without-default-cr
+          make -C hack/ci/ verify-kyma
 
-      - name: Setup and test NATS CR
+      - name: Setup & test NATS CR
         run: |
+          make e2e-setup
+
+      - name: Run NATS bench
+        run: |
+          go install github.com/nats-io/natscli/nats@latest
+          export PATH=$HOME/go/bin:$PATH
+          make e2e-bench
+
+      - name: Test NATS-server
+        run: |
+          make e2e-nats-server
+
+      - name: Cleanup NATS CR
+        run: |
+          make e2e-cleanup
+  e2e-upgrade-fast-channel: # This job tests the upgrade of NATS module from latest release from fast channel to current commit.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install k3d tools
+        uses: nolar/setup-k3d-k3s@v1
+        with:
+          # This is the Kubernetes version used by k3d. See https://kubernetes.io/releases/
+          version: v1.26.5
+          skip-creation: true
+
+      - name: Install Kyma CLI & setup k3d cluster using kyma CLI
+        run: |
+          make kyma
+          make -C hack/ci/ create-k3d
+          kubectl version
+          kubectl cluster-info
+
+      - name: Deploy lifecycle-manager
+        run: |
+          make -C hack/ci/ install-lifecycle-manager
+
+      - name: Install latest released module template from fast channel & enable NATS module
+        run: |
+          make -C hack/ci/ install-latest-module-template-fast
+          make -C hack/ci/ enable-module-without-default-cr
+          make -C hack/ci/ verify-kyma
+
+      - name: Setup & test NATS CR
+        run: |
+          make e2e-setup
+
+      - name: Wait for the 'pull-nats-manager-build' job to succeed
+        uses: mfaizanse/wait-for-git-commit-status-action@v1.0.6
+        with:
+          context: "pull-nats-manager-build"
+          commit_ref: "${{ github.event.pull_request.head.sha }}" # Note: 'github.event.pull_request.head.sha' is not same as 'github.sha' on pull requests.
+          timeout: 600000 # 10 minutes in milliseconds
+          # The check interval is kept long otherwise it will exhaust the GitHub rate limit (More info: https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limiting)
+          check_interval: 60000 # 1 minute in milliseconds
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_OWNER: "${{ github.repository_owner }}"
+          GITHUB_REPO: "nats-manager"
+
+      - name: Wait for the 'pull-nats-module-build' job to succeed
+        id: wait-nats-module-build
+        uses: mfaizanse/wait-for-git-commit-status-action@v1.0.6
+        with:
+          context: "pull-nats-module-build"
+          commit_ref: "${{ github.event.pull_request.head.sha }}" # Note: 'github.event.pull_request.head.sha' is not same as 'github.sha' on pull requests.
+          timeout: 600000 # 10 minutes in milliseconds
+          # The check interval is kept long otherwise it will exhaust the GitHub rate limit (More info: https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limiting)
+          check_interval: 60000 # 1 minute in milliseconds
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_OWNER: "${{ github.repository_owner }}"
+          GITHUB_REPO: "nats-manager"
+
+      - name: Download & install the new NATS module template from current commit
+        env:
+          PR_NUMBER: "${{ github.event.number }}"
+          COMMIT_STATUS_JSON: "${{ steps.wait-nats-module-build.outputs.json }}"
+        run: |
+          make -C hack/ci/ download-module-template
+          make -C hack/ci/ install-module-template
+          make -C hack/ci/ verify-kyma
+
+      - name: Wait for new changes to be reflected
+        description: Waits for NATS-manager image to be updated and NATS CR readiness.
+        run: |
+          export MANAGER_IMAGE=${DOCKER_IMAGE}
           make e2e-setup
 
       - name: Run NATS bench

--- a/.github/workflows/pull-with-lifecycle-manager.yaml
+++ b/.github/workflows/pull-with-lifecycle-manager.yaml
@@ -164,7 +164,7 @@ jobs:
           make -C hack/ci/ verify-kyma
 
       - name: Wait for new changes to be reflected
-        description: Waits for NATS-manager image to be updated and NATS CR readiness.
+        # Waits for NATS-manager image to be updated and NATS CR readiness.
         run: |
           export MANAGER_IMAGE=${DOCKER_IMAGE}
           make e2e-setup

--- a/.github/workflows/push-with-lifecycle-manager.yaml
+++ b/.github/workflows/push-with-lifecycle-manager.yaml
@@ -163,7 +163,7 @@ jobs:
           make -C hack/ci/ verify-kyma
 
       - name: Wait for new changes to be reflected
-        description: Waits for NATS-manager image to be updated and NATS CR readiness.
+        # Waits for NATS-manager image to be updated and NATS CR readiness.
         env:
           COMMIT_SHA: "${{ github.sha }}"
         run: |

--- a/.github/workflows/push-with-lifecycle-manager.yaml
+++ b/.github/workflows/push-with-lifecycle-manager.yaml
@@ -1,6 +1,7 @@
 name: push-with-lifecycle-manager
 
 env:
+  DOCKER_IMAGE: "europe-docker.pkg.dev/kyma-project/prod/nats-manager"
   E2E_LOG_LEVEL: debug
   KYMA_STABILITY: "unstable"
   KYMA: "./hack/kyma"
@@ -68,13 +69,106 @@ jobs:
           make -C hack/ci/ download-module-template
           kubectl apply -f module-template.yaml --dry-run=client
 
-      - name: Install & enabled NATS module template
+      - name: Install & enable NATS module template
         run: |
           make -C hack/ci/ install-module-template
           make -C hack/ci/ enable-module-without-default-cr
+          make -C hack/ci/ verify-kyma
 
-      - name: Setup and test NATS CR
+      - name: Setup & test NATS CR
         run: |
+          make e2e-setup
+
+      - name: Run NATS bench
+        run: |
+          go install github.com/nats-io/natscli/nats@latest
+          export PATH=$HOME/go/bin:$PATH
+          make e2e-bench
+
+      - name: Test NATS-server
+        run: |
+          make e2e-nats-server
+
+      - name: Cleanup NATS CR
+        run: |
+          make e2e-cleanup
+  e2e-upgrade-fast-channel: # This job tests the upgrade of NATS module from latest release from fast channel to current commit.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install k3d tools
+        uses: nolar/setup-k3d-k3s@v1
+        with:
+          # This is the Kubernetes version used by k3d. See https://kubernetes.io/releases/
+          version: v1.26.5
+          skip-creation: true
+
+      - name: Install Kyma CLI & setup k3d cluster using kyma CLI
+        run: |
+          make kyma
+          make -C hack/ci/ create-k3d
+          kubectl version
+          kubectl cluster-info
+
+      - name: Deploy lifecycle-manager
+        run: |
+          make -C hack/ci/ install-lifecycle-manager
+
+      - name: Install latest released module template from fast channel & enable NATS module
+        run: |
+          make -C hack/ci/ install-latest-module-template-fast
+          make -C hack/ci/ enable-module-without-default-cr
+          make -C hack/ci/ verify-kyma
+
+      - name: Setup & test NATS CR
+        run: |
+          make e2e-setup
+
+      - name: Wait for the 'post-nats-manager-build' job to succeed
+        uses: mfaizanse/wait-for-git-commit-status-action@v1.0.6
+        with:
+          context: "post-nats-manager-build"
+          commit_ref: "${{ github.sha }}"
+          timeout: 600000 # 10 minutes in milliseconds
+          # The check interval is kept long otherwise it will exhaust the GitHub rate limit (More info: https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limiting)
+          check_interval: 60000 # 1 minute in milliseconds
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_OWNER: "${{ github.repository_owner }}"
+          GITHUB_REPO: "nats-manager"
+
+      - name: Wait for the 'post-nats-module-build' job to succeed
+        id: wait-nats-module-build
+        uses: mfaizanse/wait-for-git-commit-status-action@v1.0.6
+        with:
+          context: "post-nats-module-build"
+          commit_ref: "${{ github.sha }}"
+          timeout: 600000 # 10 minutes in milliseconds
+          # The check interval is kept long otherwise it will exhaust the GitHub rate limit (More info: https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limiting)
+          check_interval: 60000 # 1 minute in milliseconds
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_OWNER: "${{ github.repository_owner }}"
+          GITHUB_REPO: "nats-manager"
+
+      - name: Download & install the new NATS module template from current commit
+        env:
+          PR_NUMBER: "${{ github.event.number }}"
+          COMMIT_STATUS_JSON: "${{ steps.wait-nats-module-build.outputs.json }}"
+        run: |
+          make -C hack/ci/ download-module-template
+          make -C hack/ci/ install-module-template
+          make -C hack/ci/ verify-kyma
+
+      - name: Wait for new changes to be reflected
+        description: Waits for NATS-manager image to be updated and NATS CR readiness.
+        env:
+          COMMIT_SHA: "${{ github.sha }}"
+        run: |
+          export DOCKER_TAG="$(shell date +v%Y%m%d)-$(shell echo ${COMMIT_SHA} | head -c 8)"
+          export MANAGER_IMAGE="${DOCKER_IMAGE}:${DOCKER_TAG}"
           make e2e-setup
 
       - name: Run NATS bench

--- a/Makefile
+++ b/Makefile
@@ -263,7 +263,7 @@ $(KYMA):
 # e2e testing is done here
 .PHONY: e2e-setup
 e2e-setup:
-	go test ./e2e/setup/setup_test.go --tags=e2e
+	go test -v ./e2e/setup/setup_test.go --tags=e2e
 
 .PHONY: e2e-bench
 e2e-bench:
@@ -275,7 +275,7 @@ e2e-nats-server:
 
 .PHONY: e2e-cleanup
 e2e-cleanup:
-	go test ./e2e/cleanup/cleanup_test.go --tags=e2e
+	go test -v ./e2e/cleanup/cleanup_test.go --tags=e2e
 
 .PHONY: e2e-only
 e2e-only: e2e-setup e2e-bench e2e-nats-server e2e-cleanup

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -22,7 +22,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/e2e/common/fixtures/fixtures.go
+++ b/e2e/common/fixtures/fixtures.go
@@ -10,18 +10,19 @@ import (
 )
 
 const (
-	NamespaceName   = "kyma-system"
-	CRName          = "eventing-nats"
-	STSName         = CRName
-	ContainerName   = "nats"
-	pvcLabel        = "app.kubernetes.io/name=nats"
-	podLabel        = "nats_cluster=eventing-nats"
-	ClusterSize     = 3
-	SecretName      = "eventing-nats-secret" //nolint:gosec // This is used for test purposes only.
-	CMName          = "eventing-nats-config"
-	FileStorageSize = "1Gi"
-	MemStorageSize  = "1Gi"
-	True            = "true"
+	NamespaceName         = "kyma-system"
+	ManagerDeploymentName = "nats-manager"
+	CRName                = "eventing-nats"
+	STSName               = CRName
+	ContainerName         = "nats"
+	pvcLabel              = "app.kubernetes.io/name=nats"
+	podLabel              = "nats_cluster=eventing-nats"
+	ClusterSize           = 3
+	SecretName            = "eventing-nats-secret" //nolint:gosec // This is used for test purposes only.
+	CMName                = "eventing-nats-config"
+	FileStorageSize       = "1Gi"
+	MemStorageSize        = "1Gi"
+	True                  = "true"
 )
 
 func NATSCR() *natsv1alpha1.NATS {

--- a/e2e/scripts/natsserver.sh
+++ b/e2e/scripts/natsserver.sh
@@ -19,6 +19,6 @@ function kill_port_forward() {
 # This kills the port-forwards even if the test fails.
 trap kill_port_forward ERR
 
-go test ./e2e/natsserver/natsserver_test.go --tags=e2e
+go test -v ./e2e/natsserver/natsserver_test.go --tags=e2e
 
 kill_port_forward

--- a/hack/ci/Makefile
+++ b/hack/ci/Makefile
@@ -26,6 +26,10 @@ download-module-template: ## Downloads the module-template from the module-build
 	export PROJECT_ROOT="${PROJECT_ROOT}" \
 	&& ../get_module_template_from_build_job.sh
 
+.PHONY: install-latest-module-template-fast
+install-latest-module-template-fast: ## Downloads and applies the latest released module-template from fast channel.
+	kubectl apply -f https://github.com/kyma-project/nats-manager/releases/latest/download/module-template.yaml
+
 .PHONY: create-kyma-system-ns
 create-kyma-system-ns: ## Create kyma-system namespace.
 	kubectl create ns kyma-system
@@ -47,3 +51,7 @@ install-lifecycle-manager: ## Deploys lifecycle-manager.
 .PHONY: create-k3d
 create-k3d: ## Create k3d with kyma CRDs.
 	"${KYMA_CLI}" provision k3d -p 8081:80@loadbalancer -p 8443:443@loadbalancer --registry-port ${REGISTRY_PORT} --name ${CLUSTER_NAME} --ci
+
+.PHONY: verify-kyma
+verify-kyma: ## Wait for Kyma CR to be in Ready state.
+	../verify_kyma_status.sh

--- a/hack/verify_kyma_status.sh
+++ b/hack/verify_kyma_status.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+function get_kyma_status () {
+	local number=1
+	while [[ $number -le 100 ]] ; do
+		echo ">--> checking kyma status #$number"
+		local STATUS=$(kubectl get kyma -n kyma-system default-kyma -o jsonpath='{.status.state}')
+		echo "kyma status: ${STATUS:='UNKNOWN'}"
+		[[ "$STATUS" == "Ready" ]] && return 0
+		sleep 5
+        	((number = number + 1))
+	done
+
+	kubectl get all --all-namespaces
+	exit 1
+}
+
+get_kyma_status


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Added [pull+push] e2e upgrade from fast-channel to current commit test jobs
- Made e2e test verbose.
- Updated e2e tests to check readiness of nats-manager deployment and NATS CR before starting the test cases.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/nats-manager/issues/84