### PR TITLE
Refine trigger for github action

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,7 +10,8 @@ on:
     paths-ignore:
       - "**.md"
       - "LICENSE"
-      - "docs"
+      - "docs/**"
+      - "**.yml"
 
 jobs:
   e2e:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,7 +11,6 @@ on:
       - "**.md"
       - "LICENSE"
       - "docs/**"
-      - ".github/**"
 
 jobs:
   e2e:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,7 +11,7 @@ on:
       - "**.md"
       - "LICENSE"
       - "docs/**"
-      - "**.yml"
+      - ".github/**"
 
 jobs:
   e2e:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,6 +7,10 @@ env:
 on:
   pull_request:
     branches: [ "main" ]
+    paths-ignore:
+      - "**.md"
+      - "LICENSE"
+      - "docs"
 
 jobs:
   e2e:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,6 +11,7 @@ on:
       - "**.md"
       - "LICENSE"
       - "docs/**"
+      - ".github/**"
 
 jobs:
   e2e:

--- a/.github/workflows/pull-with-lifecycle-manager.yaml
+++ b/.github/workflows/pull-with-lifecycle-manager.yaml
@@ -12,7 +12,7 @@ on:
     paths-ignore:
       - "**.md"
       - "LICENSE"
-      - "docs"
+      - "docs/**"
 
 jobs:
   e2e:

--- a/.github/workflows/pull-with-lifecycle-manager.yaml
+++ b/.github/workflows/pull-with-lifecycle-manager.yaml
@@ -13,7 +13,6 @@ on:
       - "**.md"
       - "LICENSE"
       - "docs/**"
-      - ".github/**"
 
 jobs:
   e2e:

--- a/.github/workflows/pull-with-lifecycle-manager.yaml
+++ b/.github/workflows/pull-with-lifecycle-manager.yaml
@@ -9,6 +9,10 @@ env:
 on:
   pull_request:
     branches: [ "main" ]
+    paths-ignore:
+      - "**.md"
+      - "LICENSE"
+      - "docs"
 
 jobs:
   e2e:

--- a/.github/workflows/pull-with-lifecycle-manager.yaml
+++ b/.github/workflows/pull-with-lifecycle-manager.yaml
@@ -13,6 +13,7 @@ on:
       - "**.md"
       - "LICENSE"
       - "docs/**"
+      - ".github/**"
 
 jobs:
   e2e:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**
The `pull-nats-module-build` job is [not triggered](https://github.com/grischperl/test-infra/blob/f91ece6ce74ef8478091c872dc111c41baddbabe/prow/jobs/nats-manager/nats-manager-generic.yaml#L95) if docs, README or the License file is changed.
The two `e2e` github actions run for every change on main, but wait for the `pull-nats-module-build` job. Thus, they fail on PRs where f.ex. only the README file was changed, because the action is waiting for a job that wasn't even triggered.

Changes proposed in this pull request:

Do not trigger the github action for changes to:

- any `.md` file
- the `LICENSE` file
- any file in the `docs` repository
- any file in the `.github` repository