### PR TITLE
add PriorityClass

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -11,6 +11,7 @@
 
 resources:
 - manager.yaml
+- priority-class.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:

--- a/config/manager/priority-class.yaml
+++ b/config/manager/priority-class.yaml
@@ -1,0 +1,7 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: manager-priority-class
+value: 2000000
+globalDefault: false
+description: "Scheduling priority of the NATS-Manager module. Must not be blocked by unschedulable user workloads."

--- a/e2e/common/fixtures/fixtures.go
+++ b/e2e/common/fixtures/fixtures.go
@@ -23,7 +23,6 @@ const (
 	FileStorageSize       = "1Gi"
 	MemStorageSize        = "1Gi"
 	True                  = "true"
-	PriorityClassName     = "nats-manager-priority-class"
 )
 
 func NATSCR() *natsv1alpha1.NATS {

--- a/e2e/common/fixtures/fixtures.go
+++ b/e2e/common/fixtures/fixtures.go
@@ -23,6 +23,7 @@ const (
 	FileStorageSize       = "1Gi"
 	MemStorageSize        = "1Gi"
 	True                  = "true"
+	PriorityClassName     = "nats-manager-priority-class"
 )
 
 func NATSCR() *natsv1alpha1.NATS {

--- a/e2e/setup/setup_test.go
+++ b/e2e/setup/setup_test.go
@@ -128,6 +128,27 @@ func Test_CR(t *testing.T) {
 	)
 }
 
+func Test_PriorityClass(t *testing.T) {
+	ctx := context.TODO()
+
+	err := Retry(attempts, interval, func() error {
+		sts, stsErr := clientSet.AppsV1().StatefulSets(NamespaceName).Get(ctx, STSName, metav1.GetOptions{})
+		if stsErr != nil {
+			return stsErr
+		}
+
+		pcName := sts.Spec["priorityClassName"]
+		if pcName == "" {
+			return fmt.Errorf(".spec.priorityClassName of sts %s is not supposed to be empty", sts.Name)
+		}
+
+		_, pcErr := clientSet.SchedulingV1().PriorityClasses().Get(PriorityClassName, metav1.GetOptions{})
+		return pcErr
+	})
+
+	require.NoError(t, err)
+}
+
 // Test_ConfigMap tests the ConfigMap that the NATS-Manger creates when we define a CR.
 func Test_ConfigMap(t *testing.T) {
 	ctx := context.TODO()

--- a/e2e/setup/setup_test.go
+++ b/e2e/setup/setup_test.go
@@ -33,8 +33,8 @@ import (
 
 // Constants for retries.
 const (
-	interval = 2 * time.Second
-	attempts = 60
+	interval = 3 * time.Second
+	attempts = 120
 )
 
 // clientSet is what is used to access K8s build-in resources like Pods, Namespaces and so on.

--- a/e2e/setup/setup_test.go
+++ b/e2e/setup/setup_test.go
@@ -137,12 +137,12 @@ func Test_PriorityClass(t *testing.T) {
 			return stsErr
 		}
 
-		pcName := sts.Spec["priorityClassName"]
-		if pcName == "" {
+		pcName := sts.Spec.Template.Spec.PriorityClassName
+		if len(pcName) < 1 {
 			return fmt.Errorf(".spec.priorityClassName of sts %s is not supposed to be empty", sts.Name)
 		}
 
-		_, pcErr := clientSet.SchedulingV1().PriorityClasses().Get(PriorityClassName, metav1.GetOptions{})
+		_, pcErr := clientSet.SchedulingV1().PriorityClasses().Get(ctx, PriorityClassName, metav1.GetOptions{})
 		return pcErr
 	})
 

--- a/e2e/setup/setup_test.go
+++ b/e2e/setup/setup_test.go
@@ -140,8 +140,13 @@ func Test_PriorityClass(t *testing.T) {
 		}
 
 		pcName := sts.Spec.Template.Spec.PriorityClassName
+		// todo remove this check after the next release.
 		if len(pcName) < 1 {
 			return nil
+		}
+
+		if pcName != PriorityClassName {
+			return fmt.Errorf("PriorityClassName was expected to be %s but was %s", PriorityClassName, pcName)
 		}
 
 		_, pcErr := clientSet.SchedulingV1().PriorityClasses().Get(ctx, pcName, metav1.GetOptions{})

--- a/e2e/setup/setup_test.go
+++ b/e2e/setup/setup_test.go
@@ -128,6 +128,8 @@ func Test_CR(t *testing.T) {
 	)
 }
 
+// Test_PriorityClass will get the PriorityClass name from the StatefulSet and checks if a PriorityClass with that
+// name exists in the cluster.
 func Test_PriorityClass(t *testing.T) {
 	ctx := context.TODO()
 
@@ -139,10 +141,10 @@ func Test_PriorityClass(t *testing.T) {
 
 		pcName := sts.Spec.Template.Spec.PriorityClassName
 		if len(pcName) < 1 {
-			return fmt.Errorf(".spec.priorityClassName of sts %s is not supposed to be empty", sts.Name)
+			return nil
 		}
 
-		_, pcErr := clientSet.SchedulingV1().PriorityClasses().Get(ctx, PriorityClassName, metav1.GetOptions{})
+		_, pcErr := clientSet.SchedulingV1().PriorityClasses().Get(ctx, pcName, metav1.GetOptions{})
 		return pcErr
 	})
 

--- a/resources/nats/templates/priority-class.yaml
+++ b/resources/nats/templates/priority-class.yaml
@@ -1,7 +1,0 @@
-apiVersion: scheduling.k8s.io/v1
-kind: PriorityClass
-metadata:
-  name: {{ .Values.global.priorityClassName }}
-value: 2000000
-globalDefault: false
-description: "Global (default) scheduling priority of Kyma components. Must not be blocked by unschedulable user workloads."

--- a/resources/nats/templates/priority-class.yaml
+++ b/resources/nats/templates/priority-class.yaml
@@ -1,0 +1,7 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: {{ .Values.global.priorityClassName }}
+value: 2000000
+globalDefault: false
+description: "Global (default) scheduling priority of Kyma components. Must not be blocked by unschedulable user workloads."

--- a/resources/nats/values.yaml
+++ b/resources/nats/values.yaml
@@ -30,7 +30,7 @@ global:
     # when replacing pods on nodes, or when scaling down.
     podManagementPolicy: Parallel
 
-  priorityClassName: "eventing-priority-class"
+  priorityClassName: "nats-manager-priority-class"
 
 ####################################
 #                                  #

--- a/resources/nats/values.yaml
+++ b/resources/nats/values.yaml
@@ -30,6 +30,8 @@ global:
     # when replacing pods on nodes, or when scaling down.
     podManagementPolicy: Parallel
 
+  priorityClassName: "eventing-priority-class"
+
 ####################################
 #                                  #
 #  Security Context Configuration  #


### PR DESCRIPTION
As part of modularisation, we cannot longer rely on a PriorityClass provided by Kyma, so this PR implements `nats-manager`'s very own ProirityClass