### PR TITLE
fix the order in which release scripts run

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -13,13 +13,13 @@ jobs:
     name: Validate release
     runs-on: ubuntu-latest
     steps:
-      - name: Verify version follows x.y.z pattern
-        run: ./.github/scripts/check_version_format.sh ${{ github.event.inputs.version }}
-
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Verify version follows x.y.z pattern
+        run: ./.github/scripts/check_version_format.sh ${{ github.event.inputs.version }}
 
       - name: Verify that the current branch's name starts with 'release-'
         run: ./.github/scripts/verify_is_on_release_branch.sh


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

At the current version, the `create-release` workflow does an operation based on a script, which is not available at that point in time. We need to run the `checkout` first.

Changes proposed in this pull request:

- run `checkout` before `check_version_format.sh`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/nats-manager/issues/245