### PR TITLE
use cache for linting

### DIFF
--- a/.github/workflows/codequality.yml
+++ b/.github/workflows/codequality.yml
@@ -27,9 +27,11 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
-          cache: false
-      - uses: actions/checkout@v4
+          go-version-file: "go.mod"
+
+      - name: checkout code
+        uses: actions/checkout@v4
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:


### PR DESCRIPTION
**Description**

To increase performance and to avoid running into rate-limits, this PR changes the Github action workflow for linting to use caching (enabled by default).

Changes proposed in this pull request:

- enable caching in linting gha worflow
- instead of hard-coding the Go version extract it from `go.mod`
