### PR TITLE
set the right image for the release

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -66,7 +66,7 @@ jobs:
         env:
           KUSTOMIZE_VERSION: "v4.5.6"
         run: |
-          ./.github/scripts/render_and_upload_manifests.sh ${{ github.event.inputs.version }} ${{ secrets.GITHUB_TOKEN }}
+          ./.github/scripts/render_and_upload_manifests.sh ${{ github.event.inputs.version }} nats ${{ secrets.GITHUB_TOKEN }}
 
     outputs:
       release_id: ${{ steps.create-draft.outputs.release_id }}


### PR DESCRIPTION
At the moment in case of a release the image gets set to a default value of image: op-skr-registry.localhost:8888/unsigned/manager-images/nats-manager:<version> in the nats-manager.yaml due to an unset IMG var. This commit changes that by setting the var IMG. Also, the script was made more generic by removing references to nats and instead, pass the string nats as a var from the ghaw.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- set the right value for the image in the `nats-manager.yaml` in a release.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
