### PR TITLE
Upgrade NATS images to fix security issues

### DIFF
--- a/resources/nats/values.yaml
+++ b/resources/nats/values.yaml
@@ -18,7 +18,7 @@ global:
       directory: prod/external
     prometheus_nats_exporter:
       name: natsio/prometheus-nats-exporter
-      version: 0.13.0
+      version: 0.14.0
       directory: prod/external
 
   jetstream:

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -2,9 +2,9 @@ module-name: nats
 rc-tag: 1.0.2
 protecode:
   - europe-docker.pkg.dev/kyma-project/prod/nats-manager:v20231227-f488f21d
-  - europe-docker.pkg.dev/kyma-project/prod/external/natsio/prometheus-nats-exporter:0.13.0
-  - europe-docker.pkg.dev/kyma-project/prod/external/natsio/nats-server-config-reloader:0.14.0
-  - europe-docker.pkg.dev/kyma-project/prod/external/nats:v20230620-2.9.18-alpine3.18
+  - europe-docker.pkg.dev/kyma-project/prod/external/natsio/prometheus-nats-exporter:0.14.0
+  - europe-docker.pkg.dev/kyma-project/prod/external/natsio/nats-server-config-reloader:0.14.1
+  - europe-docker.pkg.dev/kyma-project/prod/external/nats:v20240102-2.10.7-alpine3.18
 whitesource:
   language: golang-mod
   subprojects: false

--- a/testutils/integration/integration.go
+++ b/testutils/integration/integration.go
@@ -729,6 +729,7 @@ func StartEnvTest(projectRootDir string, celValidationEnabled bool) (*envtest.En
 	testEnv := &envtest.Environment{
 		CRDDirectoryPaths: []string{
 			filepath.Join(projectRootDir, "config", "crd", "bases"),
+			filepath.Join(projectRootDir, "config", "crd", "external"),
 		},
 		ErrorIfCRDPathMissing:    true,
 		AttachControlPlaneOutput: attachControlPlaneOutput,

--- a/testutils/integration/integration.go
+++ b/testutils/integration/integration.go
@@ -729,7 +729,6 @@ func StartEnvTest(projectRootDir string, celValidationEnabled bool) (*envtest.En
 	testEnv := &envtest.Environment{
 		CRDDirectoryPaths: []string{
 			filepath.Join(projectRootDir, "config", "crd", "bases"),
-			filepath.Join(projectRootDir, "config", "crd", "external"),
 		},
 		ErrorIfCRDPathMissing:    true,
 		AttachControlPlaneOutput: attachControlPlaneOutput,


### PR DESCRIPTION
**Description**
Upgrade prometheus-nats-exporter, nats-server-config-reloader and nats server image in sec scanners config.

**Reason**
We get security issues related to this images