### PR TITLE
Chore: Simplify retry functions

### DIFF
--- a/e2e/common/retry.go
+++ b/e2e/common/retry.go
@@ -8,16 +8,15 @@ func Retry(attempts int, interval time.Duration, fn func() error) error {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	var err error
-	for { //nolint:gosimple//There is no range here.
-		select {
-		case <-ticker.C:
-			attempts--
-			err = fn()
-			if err == nil || attempts == 0 {
-				return err
-			}
+	for range ticker.C {
+		attempts--
+		err = fn()
+		if err == nil || attempts == 0 {
+			return err
 		}
 	}
+	// Return nil if all attempts fail.
+	return nil
 }
 
 func RetryGet[T any](attempts int, interval time.Duration, fn func() (*T, error)) (*T, error) {
@@ -25,14 +24,13 @@ func RetryGet[T any](attempts int, interval time.Duration, fn func() (*T, error)
 	defer ticker.Stop()
 	var err error
 	var obj *T
-	for { //nolint:gosimple//There is no range here.
-		select {
-		case <-ticker.C:
-			attempts--
-			obj, err = fn()
-			if err == nil || attempts == 0 {
-				return obj, err
-			}
+	for range ticker.C {
+		attempts--
+		obj, err = fn()
+		if err == nil || attempts == 0 {
+			return obj, err
 		}
 	}
+	// Return nil object if all attempts fail.
+	return nil, err
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

[Staticcheck](https://staticcheck.dev/) does not like the `Retry` functions we use in the `e2e` tests, so let's improve them:

- Simplify the `Retry` and `RetryGet` functions.

**Tests**

Issues with changes would be caught via the `e2e` tests.

**Related**
https://github.com/kyma-project/eventing-manager/pull/503