### PR TITLE
chore: update k3d version to 1.28

### DIFF
--- a/hack/ci/Makefile
+++ b/hack/ci/Makefile
@@ -2,6 +2,7 @@ PROJECT_ROOT ?= ../..
 KYMA_CLI ?= "${PROJECT_ROOT}/${KYMA}"
 CLUSTER_NAME ?= kyma
 REGISTRY_PORT ?= 5001
+K3D_VERSION ?= 1.28.0
 
 ifndef MODULE_VERSION
 	include ${PROJECT_ROOT}/.version
@@ -21,7 +22,7 @@ install-latest-nats-manager-release: ## Install nats-manager only.
 
 .PHONY: create-k3d
 create-k3d: ## Create k3d with kyma CRDs.
-	"${KYMA_CLI}" provision k3d -p 8081:80@loadbalancer -p 8443:443@loadbalancer --registry-port ${REGISTRY_PORT} --name ${CLUSTER_NAME} --ci
+	"${KYMA_CLI}" provision k3d -p 8081:80@loadbalancer -p 8443:443@loadbalancer --registry-port ${REGISTRY_PORT} -k ${K3D_VERSION} --name ${CLUSTER_NAME} --ci
 
 .PHONY: install-k3d-tools
 install-k3d-tools: ## Create k3d with kyma CRDs.


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- default version of k3d is now 1.28

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
