### PR TITLE
chore: update go version to 1.22.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM europe-docker.pkg.dev/kyma-project/prod/external/golang:1.22.2-alpine3.19 as builder
+FROM europe-docker.pkg.dev/kyma-project/prod/external/golang:1.22.5-alpine3.19 as builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM europe-docker.pkg.dev/kyma-project/prod/external/golang:1.22.5-alpine3.19 as builder
+FROM europe-docker.pkg.dev/kyma-project/prod/external/golang:1.22.5-alpine3.20 as builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/nats-manager
 
-go 1.22.2
+go 1.22.5
 
 require (
 	dario.cat/mergo v1.0.0


### PR DESCRIPTION
## Description

Changes proposed in this pull request:

- update golang version to 1.22.5

## Related PRs
- bump golang version in external images: [test-infra/#11286](https://github.com/kyma-project/test-infra/pull/11286)