### PR TITLE
fix: retry functions

### DIFF
--- a/e2e/common/retry.go
+++ b/e2e/common/retry.go
@@ -8,15 +8,17 @@ func Retry(attempts int, interval time.Duration, fn func() error) error {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	var err error
-	for range ticker.C {
+
+	for attempts > 0 {
+		<-ticker.C
 		attempts--
 		err = fn()
-		if err == nil || attempts == 0 {
-			return err
+		if err == nil {
+			return nil
 		}
 	}
-	// Return nil if all attempts fail.
-	return nil
+	// Return the err if all attempts fail.
+	return err
 }
 
 func RetryGet[T any](attempts int, interval time.Duration, fn func() (*T, error)) (*T, error) {
@@ -24,11 +26,13 @@ func RetryGet[T any](attempts int, interval time.Duration, fn func() (*T, error)
 	defer ticker.Stop()
 	var err error
 	var obj *T
-	for range ticker.C {
+
+	for attempts > 0 {
+		<-ticker.C
 		attempts--
 		obj, err = fn()
-		if err == nil || attempts == 0 {
-			return obj, err
+		if err == nil {
+			return obj, nil
 		}
 	}
 	// Return nil object if all attempts fail.

--- a/e2e/common/retry.go
+++ b/e2e/common/retry.go
@@ -10,7 +10,7 @@ func Retry(attempts int, interval time.Duration, fn func() error) error {
 	var err error
 
 	for attempts > 0 {
-		<-ticker.C
+		<-ticker.C // Wait for the ticker interval.
 		attempts--
 		err = fn()
 		if err == nil {
@@ -28,7 +28,7 @@ func RetryGet[T any](attempts int, interval time.Duration, fn func() (*T, error)
 	var obj *T
 
 	for attempts > 0 {
-		<-ticker.C
+		<-ticker.C // Wait for the ticker interval.
 		attempts--
 		obj, err = fn()
 		if err == nil {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- make the `retry` functions used in e2e tests linter-compliant

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
