### PR TITLE
fix: pin natscli version

### DIFF
--- a/.github/workflows/pull-e2e-test.yml
+++ b/.github/workflows/pull-e2e-test.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Run NATS bench
         run: |
-          go install github.com/nats-io/natscli/nats@latest
+          go install github.com/nats-io/natscli/nats@v0.1.6
           export PATH=$HOME/go/bin:$PATH
           make e2e-bench
 

--- a/.github/workflows/push-e2e-upgrade-test.yaml
+++ b/.github/workflows/push-e2e-upgrade-test.yaml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Run NATS bench
         run: |
-          go install github.com/nats-io/natscli/nats@latest
+          go install github.com/nats-io/natscli/nats@v0.1.6
           export PATH=$HOME/go/bin:$PATH
           make e2e-bench
 


### PR DESCRIPTION
fix version notation

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- pin the version of natcli (as used in GH workflows) to `v0.1.6` 
**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
